### PR TITLE
Add method to generate access token

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-mpesa-wrapper "1.0.1-SNAPSHOT"
+(defproject clojure-mpesa-wrapper "1.0.3-SNAPSHOT"
   :description "A clojure wrapper around mpesa daraja api"
   :url "https://github.com/MawiraIke/clojure-mpesa-wrapper"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
When calling the functions you don't have to pass the access-token as "Bearer <access-token>" anymore, just pass the access-token directly.


Signed-off-by: Ike Mawira <mawiraike@gmail.com>